### PR TITLE
Proxy cache master merge

### DIFF
--- a/tourney/info.json
+++ b/tourney/info.json
@@ -5,6 +5,6 @@
     "SHORT" : "Search and look for new Tournaments in clash royale",
     "DESCRIPTION" : "Uses statsroyale to look for open Tournaments and announces them in a channel.",
     "TAGS" : ["clashroyale", "legend","management", "Tournaments"],
-    "REQUIREMENTS" : ["bs4", "json","requests","os","asyncio"],
+    "REQUIREMENTS" : ["bs4", "json","requests","os","asyncio","proxybroker"],
     "HIDDEN" : false
 }

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -235,6 +235,16 @@ class tournament:
 			self.settings[serverid] = channel.id
 			await self.bot.say("Tournament channel for this server set to "+channel.mention)
 		self.save_data()
+		
+	def _get_embed(self, aTourney):
+		embed=discord.Embed(title="Open Tournament", color=randint(0, 0xffffff))
+		embed.set_thumbnail(url='https://statsroyale.com/images/tournament.png')
+		embed.add_field(name="Title", value=title, inline=True)
+		embed.add_field(name="Tag", value="#"+hashtag, inline=True)
+		embed.add_field(name="Players", value=str(totalPlayers) + "/" + str(maxPlayers), inline=True)
+		embed.add_field(name="Ends In", value=sec2tme(timeLeft), inline=True)
+		embed.add_field(name="Top prize", value="<:coin:380832316932489268> " + str(cards) + "     <:tournamentcards:380832770454192140> " +  str(coins), inline=True)
+		embed.set_footer(text=credits, icon_url=creditIcon)
 
 def check_folders():
 	if not os.path.exists("data/tourney"):

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -7,10 +7,11 @@ import random
 import json
 from cogs.utils import checks
 from .utils.dataIO import dataIO
+
 import os
+
 from fake_useragent import UserAgent
 from datetime import date, datetime, timedelta
-from proxybroker import Broker
 
 lastTag = '0'
 creditIcon = "https://i.imgur.com/TP8GXZb.png"
@@ -117,25 +118,31 @@ class tournament:
 			print(resp) 
 			raise
 		finally:
-			return (url, data)
+			return data
 			
 	async def _fetch_tourney(self):
 		"""Fetch tournament data. Run sparingly"""
 		url = "{}".format('http://statsroyale.com/tournaments?appjson=1')
-		return await self._gather_proxy(url)
+		proxy = await self._get_proxy()
+		data = await self._fetch(url, proxy)
+		
+		return data
 		
 	async def _API_tourney(self, hashtag):
 		"""Fetch API tourney from hashtag"""
 		url = "{}{}".format('http://api.cr-api.com/tournaments/',hashtag)
-		return await self._gather_proxy(url)
-	
-	async def _gather_proxy(self, url):
-		host, port = "127.0.0.1", 8080
-		
-		proxy = 'http://{}:{}'.format(host, port)
-		urlOut, data = await self._fetch(url, proxy)
+		proxy = await self._get_proxy()
+		data = await self._fetch(url, proxy)
 		
 		return data
+	
+	async def _get_proxy(self):
+		host = random.choice(proxies_list)
+		port = 80
+		proxy = 'http://{}:{}'.format(host, port)
+		
+		return proxy
+		
 	
 	async def _expire_cache(self):
 		await asyncio.sleep(900)
@@ -202,18 +209,6 @@ class tournament:
 					await self.bot.send_message(channel, embed=embed) # Family
 					
 			#await self.bot.send_message(discord.Object(id='363728974821457923'), embed=embed) # testing
-
-	@commands.command(pass_context=True, no_pm=True)
-	@checks.is_owner()
-	async def proxytest(self, ctx):
-		url = 'http://proxy-hunter.blogspot.com/2010/03/18-03-10-speed-l1-hunter-proxies-310.html'
-		async with aiohttp.get(url) as response:
-			tree = BeautifulSoup(await response.text(), "html.parser")
-		regex  = re.compile(r'^(\d{3}).(\d{1,3}).(\d{1,3}).(\d{1,3}):(\d{2,4})')
-		proxylist = tree.findAll(attrs = {"class":"Apple-style-span", "style": "color: black;"}, text = regex)
-		data = proxylist[0]
-		for x in data.split('\n'):
-			print(x)
 		
 	@commands.command(pass_context=True, no_pm=True)
 	@checks.is_owner()

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -160,6 +160,8 @@ class tournament:
 	async def _expire_cache(self):
 		await asyncio.sleep(900)
 		self.cacheUpdated = False
+		if not self.cacheUpdated:
+			await self._update_cache()  # This will automatically post top tournaments
 	
 	async def _update_cache(self):
 		try:

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -258,6 +258,15 @@ class tournament:
 			await self.bot.say("Tournament channel for this server set to "+channel.mention)
 		self.save_data()
 		
+	@commands.command(pass_context=True, no_pm=True)
+	@checks.admin_or_permissions(administrator=True)
+	async def tourneywipe(self, ctx, channel: discord.Channel=None):
+		
+		self.settings = {}
+		await self.bot.say("Tournament channel for all servers cleared")
+
+		self.save_data()
+		
 	async def _get_embed(self, aTourney):
 		"""Builds embed for tourney
 		Uses cr-api.com if available"""

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -109,9 +109,8 @@ class tournament:
 	async def _fetch(self, url, proxy_url, headers):
 		resp = None
 		try:
-			async with aiohttp.ClientSession() as session:
-				async with session.get(url, timeout=30, proxy=proxy_url, headers=headers) as resp:
-					data = await resp.json()
+			async with self.session.get(url, timeout=30, proxy=proxy_url, headers=headers) as resp:
+				data = await resp.json()
 		except (aiohttp.errors.ClientOSError, aiohttp.errors.ClientResponseError,
 				aiohttp.errors.ServerDisconnectedError) as e:
 			print('Error. url: %s; error: %r' % (url, e))

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -11,6 +11,7 @@ import os
 from fake_useragent import UserAgent
 
 from proxybroker import Broker
+from collections import deque
 
 lastTag = '0'
 creditIcon = "https://i.imgur.com/TP8GXZb.png"
@@ -64,9 +65,9 @@ class tournament:
 		self.path = 'data/tourney/settings.json'
 		self.settings = dataIO.load_json(self.path)
 		self.auth = dataIO.load_json('cogs/auth.json')
-		self.queue = asyncio.Queue()
+		self.queue = asyncio.Queue(maxsize=10)
 		self.broker = Broker(self.queue)
-		self.proxylist = list(proxies_list)
+		self.proxylist = deque(proxies_list,10)
 		
 	def save_data(self):
 		"""Saves the json"""
@@ -250,7 +251,7 @@ class tournament:
 		return host  # Return host for now, will return proxy later
 		
 	async def _proxyBroker(self):
-		self.broker.find(types=['HTTP'], limit=10)
+		await self.broker.find(types=['HTTP'], limit=10)
 		await asyncio.sleep(120)
 	
 	async def _brokerResult(self):
@@ -258,6 +259,7 @@ class tournament:
 		while True:
 			proxy = await self.queue.get()
 			if proxy is None: break
+			print(dir(proxy))
 			self.proxylist.append(proxy)
 		
 		

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -102,11 +102,11 @@ class tournament:
 		else:
 			return False
 	
-	async def _fetch(url, proxy_url):
+	async def _fetch(url, proxy_url, headers):
 		resp = None
 		try:
 			async with aiohttp.ClientSession() as session:
-				async with session.get(url, timeout=30, proxy=proxy_url) as resp:
+				async with session.get(url, timeout=30, proxy=proxy_url, headers=headers) as resp:
 					data = await resp.json()
 		except (aiohttp.errors.ClientOSError, aiohttp.errors.ClientResponseError,
 				aiohttp.errors.ServerDisconnectedError) as e:
@@ -124,7 +124,7 @@ class tournament:
 		"""Fetch tournament data. Run sparingly"""
 		url = "{}".format('http://statsroyale.com/tournaments?appjson=1')
 		proxy = await self._get_proxy()
-		data = await self._fetch(url, proxy)
+		data = await self._fetch(url, proxy, {})
 		
 		return data
 		
@@ -132,7 +132,7 @@ class tournament:
 		"""Fetch API tourney from hashtag"""
 		url = "{}{}".format('http://api.cr-api.com/tournaments/',hashtag)
 		proxy = await self._get_proxy()
-		data = await self._fetch(url, proxy)
+		data = await self._fetch(url, proxy, self.getAuth())
 		
 		return data
 	

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -180,7 +180,7 @@ class tournament:
 	async def _topTourney(self, newdata):
 		now = datetime.utcnow()
 		tourneydata = [t1 for t1 in newdata
-						if not t1['full'] and time_str(t1['endtime'], False) - now >= timedelta(seconds=600) and t1['maxPlayers']>=minPlayers]
+						if not t1['full'] and time_str(t1['endtime'], False) - now >= timedelta(seconds=600) and t1['maxPlayers']>50]
 		
 		for data in tourneydata:
 			embed = self._get_embed(data)

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -263,7 +263,7 @@ class tournament:
 		Uses cr-api.com if available"""
 		
 		try:
-			bTourney = self._API_tourney(aTourney['hashtag'])
+			bTourney = await self._API_tourney(aTourney['hashtag'])
 		except:
 			bTourney = None
 			

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -178,6 +178,7 @@ class tournament:
 
 
 	async def _topTourney(self, newdata):
+		now = datetime.utcnow()
 		tourneydata = [t1 for t1 in newdata
 						if not t1['full'] and time_str(t1['endtime'], False) - now >= timedelta(seconds=600) and t1['maxPlayers']>=minPlayers]
 		

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -18,17 +18,18 @@ creditIcon = "https://i.imgur.com/TP8GXZb.png"
 credits = "Bot by GR8 | Titan"
 
 proxies_list = [
-	'94.249.160.49:6998',
-	'93.127.128.41:7341',
-	'107.175.43.100:6858',
-	'64.44.18.31:3691',
-	'172.82.173.100:5218',
-	'172.82.177.111:3432',
-	'45.43.219.185:2461',
-	'45.43.218.82:3577',
-	'173.211.31.3:8053',
-	'195.162.4.111:4762'
 ]
+	# '94.249.160.49:6998',
+	# '93.127.128.41:7341',
+	# '107.175.43.100:6858',
+	# '64.44.18.31:3691',
+	# '172.82.173.100:5218',
+	# '172.82.177.111:3432',
+	# '45.43.219.185:2461',
+	# '45.43.218.82:3577',
+	# '173.211.31.3:8053',
+	# '195.162.4.111:4762'
+# ]
 
 # Converts maxPlayers to Cards
 def getCards(maxPlayers):
@@ -244,11 +245,12 @@ class tournament:
 		
 	
 	async def _get_proxy(self):
-		host = random.choice(self.proxylist)
-		port = 80
-		proxy = 'http://{}:{}'.format(host, port)
+		proxy = random.choice(self.proxylist)
+		host = proxy.host
+		port = proxy.port
+		proxystr = '{}:{}'.format(host, port)
 		
-		return host  # Return host for now, will return proxy later
+		return proxystr
 		
 	async def _proxyBroker(self):
 		await self.broker.find(types=['HTTP'], limit=10)
@@ -259,7 +261,6 @@ class tournament:
 		while True:
 			proxy = await self.queue.get()
 			if proxy is None: break
-			print(dir(proxy))
 			self.proxylist.append(proxy)
 		
 		

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -213,7 +213,10 @@ class tournament:
 				
 			for serverid in self.settings.keys():
 				if self.settings[serverid]:
-					await self.bot.send_message(discord.Object(id=self.settings[serverid]), embed=embed) # Family
+					server = self.bot.get_server(serverid)
+					channel = server.get_channel(self.settings[serverid])
+					await self.bot.send_message(channel, embed=embed) # Family
+					
 			#await self.bot.send_message(discord.Object(id='363728974821457923'), embed=embed) # testing
 
 	

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -164,12 +164,13 @@ class tournament:
 		
 	
 	async def _get_tourney(self, minPlayers):
+		"""tourneyCache is dict of tourneys with hashtag as key"""
 		if not self.cacheUpdated:	
 			await self._update_cache()
 
 		now = datetime.utcnow()
 		
-		tourneydata = [t1 for tkey, t1 in self.tourneyCache.iteritems()
+		tourneydata = [t1 for tkey, t1 in self.tourneyCache.items()
 						if not t1['full'] and time_str(t1['endtime'], False) - now >= timedelta(seconds=600) and t1['maxPlayers']>=minPlayers]
 		
 		if not tourneydata:
@@ -178,8 +179,9 @@ class tournament:
 
 
 	async def _topTourney(self, newdata):
+		"""newdata is a list of tourneys"""
 		now = datetime.utcnow()
-		tourneydata = [t1 for tkey, t1 in newdata.iteritems()
+		tourneydata = [t1 for t1 in newdata
 						if not t1['full'] and time_str(t1['endtime'], False) - now >= timedelta(seconds=600) and t1['maxPlayers']>50]
 		
 		for data in tourneydata:
@@ -215,10 +217,10 @@ class tournament:
 			return
 		
 		
-		tourneydata = await self._get_tourney(minPlayers)
+		tourney = await self._get_tourney(minPlayers)
 		
 		if tourneydata:
-			embed = self._get_embed(tourneydata['tournaments'][x])
+			embed = self._get_embed(tourney)
 			await self.bot.say(embed=embed)
 		else:
 			await self.bot.say("No tourney found")

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -294,7 +294,7 @@ class tournament:
 			full = aTourney['full']
 			
 		timeLeft = time_str(aTourney['endtime'], False) - now
-		timeLeft = timeLeft.seconds
+		timeLeft = int(timeLeft.total_seconds()))
 		if timeLeft < 0:
 			timeLeft = 0
 			embedtitle = "Ended Tournament"

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -216,10 +216,9 @@ class tournament:
 			await self.bot.say("Error, this command is only available for Legend Members and Guests.")
 			return
 		
-		
 		tourney = await self._get_tourney(minPlayers)
 		
-		if tourneydata:
+		if tourney:
 			embed = self._get_embed(tourney)
 			await self.bot.say(embed=embed)
 		else:

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -80,6 +80,7 @@ class tournament:
 		self.tourneyCache = dataIO.load_json(self.cachepath)
 		self.auth = dataIO.load_json('cogs/auth.json')
 		self.cacheUpdated = False
+		self.session = aiohttp.ClientSession()
 		
 	def __unload(self):
 		self.session.close()	

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -65,7 +65,7 @@ def time_str(obj, isobj):
 	if isobj:
 		return obj.strftime(fmt)
 	else:
-		return datetime.datetime.strptime(now_str, fmt)
+		return datetime.strptime(obj, fmt)
 
 
 class tournament:
@@ -102,7 +102,7 @@ class tournament:
 			return False
 	
 	def _get_proxy(self):
-		return "http://52.168.49.33"  # For now
+		return "http://67.63.33.7"  # For now
 	
 	async def _fetch_tourney(self):
 		"""Fetch tournament data. Run sparingly"""

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -169,7 +169,7 @@ class tournament:
 
 		now = datetime.utcnow()
 		
-		tourneydata = [t1 for t1 in self.tourneyCache 
+		tourneydata = [t1 for tkey, t1 in self.tourneyCache.iteritems()
 						if not t1['full'] and time_str(t1['endtime'], False) - now >= timedelta(seconds=600) and t1['maxPlayers']>=minPlayers]
 		
 		if not tourneydata:
@@ -179,7 +179,7 @@ class tournament:
 
 	async def _topTourney(self, newdata):
 		now = datetime.utcnow()
-		tourneydata = [t1 for t1 in newdata
+		tourneydata = [t1 for tkey, t1 in self.newdata.iteritems()
 						if not t1['full'] and time_str(t1['endtime'], False) - now >= timedelta(seconds=600) and t1['maxPlayers']>50]
 		
 		for data in tourneydata:
@@ -191,7 +191,7 @@ class tournament:
 			#await self.bot.send_message(discord.Object(id='363728974821457923'), embed=embed) # testing
 
 
-	@commands.group(pass_context=True, no_pm=True)
+	@commands.command(pass_context=True, no_pm=True)
 	async def tourney(self, ctx, minPlayers: int=0):
 		"""Check an open tournament in clash royale instantly"""
 
@@ -213,9 +213,9 @@ class tournament:
 		else:
 			await self.bot.say("No tourney found")
 
-	@tourney.command(pass_context=True, no_pm=True)
+	@commands.command(pass_context=True, no_pm=True)
 	@checks.admin_or_permissions(administrator=True)
-	async def channel(self, ctx, channel: discord.Channel=None):
+	async def tourneychannel(self, ctx, channel: discord.Channel=None):
 		serverid = ctx.message.server.id
 		if not channel:
 			self.settings[serverid] = None

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -300,7 +300,7 @@ class tournament:
 			full = aTourney['full']
 			
 		timeLeft = time_str(aTourney['endtime'], False) - now
-		timeLeft = int(timeLeft.total_seconds()))
+		timeLeft = int(timeLeft.total_seconds())
 		if timeLeft < 0:
 			timeLeft = 0
 			embedtitle = "Ended Tournament"

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -109,7 +109,7 @@ class tournament:
 		if not proxy:
 			return "http://67.63.33.7"  # For now
 		else:
-			return proxy
+			return "http://"+proxy
 	
 	async def _fetch_tourney(self):
 		"""Fetch tournament data. Run sparingly"""

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -131,8 +131,9 @@ class tournament:
 	
 	async def _gather_proxy(self, url):
 		host, port = '67.63.33.7', 80  # Default proxy
+		codes = [200, 301, 302]
 		broker = Broker(max_tries=1)
-		broker.serve(host=host, port=port, types=types, limit=10, max_tries=3,
+		broker.serve(host=host, port=port, types=['HTTP'], limit=10, max_tries=3,
                  prefer_connect=True, min_req_proxy=5, max_error_rate=0.5,
                  max_resp_time=8, http_allowed_codes=codes, backlog=100)
 		

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -179,7 +179,7 @@ class tournament:
 
 	async def _topTourney(self, newdata):
 		now = datetime.utcnow()
-		tourneydata = [t1 for tkey, t1 in self.newdata.iteritems()
+		tourneydata = [t1 for tkey, t1 in newdata.iteritems()
 						if not t1['full'] and time_str(t1['endtime'], False) - now >= timedelta(seconds=600) and t1['maxPlayers']>50]
 		
 		for data in tourneydata:
@@ -190,7 +190,17 @@ class tournament:
 					await self.bot.send_message(discord.Object(id=self.settings[serverid]), embed=embed) # Family
 			#await self.bot.send_message(discord.Object(id='363728974821457923'), embed=embed) # testing
 
+	
+	@commands.command(pass_context=True, no_pm=True)
+	@checks.is_owner()
+	async def showcache(self, ctx):
+		"""Displays current cache pagified"""
 
+		for page in pagify(
+			str(self.tourneyCache), shorten_by=50):
+			
+			await self.bot.say(page)
+			
 	@commands.command(pass_context=True, no_pm=True)
 	async def tourney(self, ctx, minPlayers: int=0):
 		"""Check an open tournament in clash royale instantly"""

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -130,12 +130,7 @@ class tournament:
 		return await self._gather_proxy(url)
 	
 	async def _gather_proxy(self, url):
-		host, port = '67.63.33.7', 80  # Default proxy
-		codes = [200, 301, 302]
-		broker = Broker(max_tries=1)
-		broker.serve(host=host, port=port, types=['HTTP'], limit=10, max_tries=3,
-                 prefer_connect=True, min_req_proxy=5, max_error_rate=0.5,
-                 max_resp_time=8, http_allowed_codes=codes, backlog=100)
+		host, port = "127.0.0.1", 8080
 		
 		proxy = 'http://{}:{}'.format(host, port)
 		urlOut, data = await self._fetch(url, proxy)
@@ -208,7 +203,18 @@ class tournament:
 					
 			#await self.bot.send_message(discord.Object(id='363728974821457923'), embed=embed) # testing
 
-	
+	@commands.command(pass_context=True, no_pm=True)
+	@checks.is_owner()
+	async def proxytest(self, ctx):
+		url = 'http://proxy-hunter.blogspot.com/2010/03/18-03-10-speed-l1-hunter-proxies-310.html'
+		async with aiohttp.get(url) as response:
+			tree = BeautifulSoup(await response.text(), "html.parser")
+		regex  = re.compile(r'^(\d{3}).(\d{1,3}).(\d{1,3}).(\d{1,3}):(\d{2,4})')
+		proxylist = tree.findAll(attrs = {"class":"Apple-style-span", "style": "color: black;"}, text = regex)
+		data = proxylist[0]
+		for x in data.split('\n'):
+			print(x)
+		
 	@commands.command(pass_context=True, no_pm=True)
 	@checks.is_owner()
 	async def showcache(self, ctx):

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -172,6 +172,8 @@ class tournament:
 		tourneydata = [t1 for t1 in self.tourneyCache 
 						if not t1['full'] and time_str(t1['endtime'], False) - now >= timedelta(seconds=600) and t1['maxPlayers']>=minPlayers]
 		
+		if not tourneydata:
+			return None
 		return random.choice(tourneydata)
 
 
@@ -203,10 +205,12 @@ class tournament:
 		
 		
 		tourneydata = await self._get_tourney(minPlayers)
-
-		embed = self._get_embed(tourneydata['tournaments'][x])
-		await self.bot.say(embed=embed)
-		return
+		
+		if tourneydata:
+			embed = self._get_embed(tourneydata['tournaments'][x])
+			await self.bot.say(embed=embed)
+		else:
+			await self.bot.say("No tourney found")
 
 	@tourney.command(pass_context=True, no_pm=True)
 	@checks.admin_or_permissions(administrator=True)

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -207,7 +207,7 @@ class tournament:
 						if not t1['full'] and time_str(t1['endtime'], False) - now >= timedelta(seconds=600) and t1['maxPlayers']>50]
 		
 		for data in tourneydata:
-			embed = self._get_embed(data)
+			embed = await self._get_embed(data)
 				
 			for serverid in self.settings.keys():
 				if self.settings[serverid]:
@@ -241,7 +241,7 @@ class tournament:
 		tourney = await self._get_tourney(minPlayers)
 		
 		if tourney:
-			embed = self._get_embed(tourney)
+			embed = await self._get_embed(tourney)
 			await self.bot.say(embed=embed)
 		else:
 			await self.bot.say("No tourney found")
@@ -258,7 +258,7 @@ class tournament:
 			await self.bot.say("Tournament channel for this server set to "+channel.mention)
 		self.save_data()
 		
-	def _get_embed(self, aTourney):
+	async def _get_embed(self, aTourney):
 		"""Builds embed for tourney
 		Uses cr-api.com if available"""
 		

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -101,8 +101,15 @@ class tournament:
 		else:
 			return False
 	
-	def _get_proxy(self):
-		return "http://67.63.33.7"  # For now
+	async def _get_proxy(self):
+		for i in range(0,9):  # 10 attempts
+			proxy = await proxies.get()
+			if proxy: break
+			
+		if not proxy:
+			return "http://67.63.33.7"  # For now
+		else:
+			return proxy
 	
 	async def _fetch_tourney(self):
 		"""Fetch tournament data. Run sparingly"""

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -256,7 +256,7 @@ class tournament:
 	async def _brokerResult(self):
 		await asyncio.sleep(120)
 		while True:
-			proxy = await proxies.get()
+			proxy = await self.queue.get()
 			if proxy is None: break
 			self.proxylist.append(proxy)
 		

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -250,7 +250,7 @@ class tournament:
 		return host  # Return host for now, will return proxy later
 		
 	async def _proxyBroker(self):
-		self.broker.find(types=['HTTP', 'HTTPS'], limit=10)
+		self.broker.find(types=['HTTP'], limit=10)
 		await asyncio.sleep(120)
 	
 	async def _brokerResult(self):

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -92,7 +92,7 @@ class tournament:
 		}
 
 		proxies = {
-	    	'http': random.choice(proxies_list)
+	    	'http': await self._get_proxy()
 		}
 
 		try:
@@ -235,6 +235,14 @@ class tournament:
 			self.settings[serverid] = channel.id
 			await self.bot.say("Tournament channel for this server set to "+channel.mention)
 		self.save_data()
+		
+	
+	async def _get_proxy(self):
+		host = random.choice(proxies_list)
+		port = 80
+		proxy = 'http://{}:{}'.format(host, port)
+		
+		return proxy
 
 def check_folders():
 	if not os.path.exists("data/tourney"):

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -81,6 +81,9 @@ class tournament:
 		self.auth = dataIO.load_json('cogs/auth.json')
 		self.cacheUpdated = False
 		
+	def __unload(self):
+		self.session.close()	
+	
 	def save_data(self):
 		"""Saves the json"""
 		dataIO.save_json(self.path, self.settings)

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -164,9 +164,9 @@ class tournament:
 		
 	
 	async def _get_tourney(self, minPlayers):
+		if not self.cacheUpdated:	
 			await self._update_cache()
-		if not self.cacheUpdated:
-		
+
 		now = datetime.utcnow()
 		
 		tourneydata = [t1 for t1 in self.tourneyCache 

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -149,11 +149,12 @@ class tournament:
 		return data
 	
 	async def _get_proxy(self):
-		host = random.choice(proxies_list)
-		port = 80
-		proxy = 'http://{}:{}'.format(host, port)
+		proxy = random.choice(self.proxylist)
+		host = proxy.host
+		port = proxy.port
+		proxystr = '{}:{}'.format(host, port)
 		
-		return proxy
+		return proxystr
 		
 	
 	async def _expire_cache(self):
@@ -326,14 +327,7 @@ class tournament:
 		embed.set_footer(text=credits, icon_url=creditIcon)
 		return embed
 	
-	async def _get_proxy(self):
-		proxy = random.choice(self.proxylist)
-		host = proxy.host
-		port = proxy.port
-		proxystr = '{}:{}'.format(host, port)
-		
-		return proxystr
-		
+
 	async def _proxyBroker(self):
 		await self.broker.find(types=['HTTP'], limit=10)
 		await asyncio.sleep(120)

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -102,7 +102,7 @@ class tournament:
 		else:
 			return False
 	
-	async def _fetch(url, proxy_url, headers):
+	async def _fetch(self, url, proxy_url, headers):
 		resp = None
 		try:
 			async with aiohttp.ClientSession() as session:

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -121,7 +121,7 @@ class tournament:
 			print(resp)
 			raise
 		except asyncio.TimeoutError:
-			print(resp)
+			# print(resp) # No resp to print
 			raise
 		except:
 			print(resp)
@@ -181,7 +181,7 @@ class tournament:
 		self.save_cache()
 		self.cacheUpdated=True
 		
-		await self._topTourney(newdata)  # Posts all best tourneys
+		await self._topTourney(newdata)  # Posts all best tourneys when cache is updated
 		
 		
 	
@@ -205,6 +205,8 @@ class tournament:
 		now = datetime.utcnow()
 		tourneydata = [t1 for t1 in newdata
 						if not t1['full'] and time_str(t1['endtime'], False) - now >= timedelta(seconds=600) and t1['maxPlayers']>50]
+						
+		# Adjust parameters for what qualifies as a "top" tourney here ^^^^
 		
 		for data in tourneydata:
 			embed = await self._get_embed(data)

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -279,5 +279,5 @@ def setup(bot):
 	loop = asyncio.get_event_loop()
 	loop.create_task(n.checkTourney())
 	loop.create_task(n._proxyBroker())
-	loop.create_task(n.brokerResult())
+	loop.create_task(n._brokerResult())
 	bot.add_cog(n)

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -158,6 +158,7 @@ class tournament:
 			return # On error: Don't retry, but don't mark cache as updated
 		
 		newdata = newdata['tournaments']
+		newdata = [tourney for tourney in newdata if not tourney['full']]
 		
 		for tourney in newdata:
 			if tourney["hashtag"] not in self.tourneyCache:

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -76,9 +76,9 @@ class tournament:
 		botcommander_roles = set(botcommander_roles)
 		author_roles = set(member.roles)
 		if len(author_roles.intersection(botcommander_roles)):
-		    return True
+			return True
 		else:
-		    return False
+			return False
 
 	# Returns a list with tournaments
 	def getTopTourneyNew(self):
@@ -88,11 +88,11 @@ class tournament:
 
 		ua = UserAgent()
 		headers = {
-		    "User-Agent": ua.random
+			"User-Agent": ua.random
 		}
 
 		proxies = {
-	    	'http': random.choice(proxies_list)
+			'http': random.choice(proxies_list)
 		}
 
 		try:
@@ -175,15 +175,15 @@ class tournament:
 
 		allowed = await self._is_allowed(author)
 		if not allowed:
-		    await self.bot.say("Error, this command is only available for Legend Members and Guests.")
-		    return
+			await self.bot.say("Error, this command is only available for Legend Members and Guests.")
+			return
 
 		ua = UserAgent()
 		headers = {
-		    "User-Agent": ua.random
+			"User-Agent": ua.random
 		}
 		proxies = {
-	    	'http': random.choice(proxies_list)
+			'http': random.choice(proxies_list)
 		}
 
 		try:

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -13,6 +13,8 @@ import os
 from fake_useragent import UserAgent
 from datetime import date, datetime, timedelta
 
+import aiohttp
+
 lastTag = '0'
 creditIcon = "https://i.imgur.com/TP8GXZb.png"
 credits = "Bot by GR8 | Titan"

--- a/tourney/tourney.py
+++ b/tourney/tourney.py
@@ -75,7 +75,7 @@ class tournament:
 		self.bot = bot
 		self.path = 'data/tourney/settings.json'
 		self.cachepath = 'data/tourney/tourneycache.json'
-		self.settings = dataIO.load_json(self.path)]
+		self.settings = dataIO.load_json(self.path)
 		self.tourneyCache = dataIO.load_json(self.cachepath)
 		self.auth = dataIO.load_json('cogs/auth.json')
 		self.cacheUpdated = False


### PR DESCRIPTION
This is a combination of two branches I was working on, proxy-broker and tourney-cache.

# Proxy-broker
proxy-broker replaces the proxies-list with the "proxy broker" module, which async finds open proxies from many different sources

# Tourney-cache
tourney-cache replaces the `requests` library with the async `aiohttp` method of getting. Additionally, it stores a cache of results instead of querying on each request. Datetime is used since timeLeft became unreliable on cached data. Added `[p]tourneywipe` to clear cache, a better method of cache expiration may be needed. Added '[p]showcache` for debugging (deque ?)

# Extra stuff:
I separated `[p]tourney channel` into `[p]tourneychannel`
Posts **ALL** tournaments at 100 or more players when cache is updated, this should probably be adjusted by an admin command in the future